### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+install: skip
+
+os: linux
+dist: trusty
+jdk: oraclejdk8
+
+script:
+  - cd backend && ./gradlew clean build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # STORY LINTER
 
+[![Build Status](https://travis-ci.com/jmigueprieto/ticket-linter.svg?branch=master)](https://travis-ci.com/jmigueprieto/ticket-linter)
+
 "Story Linter" is a Jira Cloud application built with Atlassian Connect. Checkout [this
 video](https://www.youtube.com/watch?v=qzxVBjV5g60) for a quick intro on Atlassian Connect Framework.
 


### PR DESCRIPTION
Added `travis.yml` to have at least a `./gradlew clean build` for the moment.