### PR TITLE
Zuul Service Proxy project.

### DIFF
--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -1,0 +1,39 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+	id("org.springframework.boot")
+	id("io.spring.dependency-management")
+	kotlin("jvm")
+	kotlin("plugin.spring")
+}
+
+group = "me.mprieto.covidio"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+extra["springCloudVersion"] = "Hoxton.SR6"
+
+dependencies {
+	implementation("org.jetbrains.kotlin:kotlin-reflect")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+	implementation("org.springframework.cloud:spring-cloud-starter-netflix-zuul")
+	testImplementation("org.springframework.boot:spring-boot-starter-test") {
+		exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+	}
+}
+
+dependencyManagement {
+	imports {
+		mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+	}
+}
+
+tasks.withType<Test> {
+	useJUnitPlatform()
+}
+
+tasks.withType<KotlinCompile> {
+	kotlinOptions {
+		freeCompilerArgs = listOf("-Xjsr305=strict")
+		jvmTarget = "1.8"
+	}
+}

--- a/gateway/settings.gradle.kts
+++ b/gateway/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "ticket-linter-gateway"

--- a/gateway/src/main/kotlin/me/mprieto/covidio/ticketlintergateway/TicketLinterGatewayApplication.kt
+++ b/gateway/src/main/kotlin/me/mprieto/covidio/ticketlintergateway/TicketLinterGatewayApplication.kt
@@ -1,0 +1,13 @@
+package me.mprieto.covidio.ticketlintergateway
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy
+
+@SpringBootApplication
+@EnableZuulProxy
+class TicketLinterGatewayApplication
+
+fun main(args: Array<String>) {
+	runApplication<TicketLinterGatewayApplication>(*args)
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+zuul:
+  routes:
+    descriptor:
+      path: /
+      url: http://localhost:8001/atlassian-connect.json
+    frontend:
+      path: /**
+      url: http://localhost:8000
+    api:
+      path: /linter/api/**
+      url: http://localhost:8001/linter/api
+

--- a/gateway/src/test/kotlin/me/mprieto/covidio/ticketlintergateway/TicketLinterGatewayApplicationTests.kt
+++ b/gateway/src/test/kotlin/me/mprieto/covidio/ticketlintergateway/TicketLinterGatewayApplicationTests.kt
@@ -1,0 +1,13 @@
+package me.mprieto.covidio.ticketlintergateway
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class TicketLinterGatewayApplicationTests {
+
+	@Test
+	fun contextLoads() {
+	}
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,5 +2,4 @@ rootProject.name = "ticket-linter"
 
 include("frontend")
 include("backend")
-
-
+include("gateway")


### PR DESCRIPTION
This Zuul Gateway Service Proxy will be very convenient for development at this moment (and for deployment later)

These are the steps to run ticket linter in dev mode locally:

1. Start the `TicketLinterGatewayApplication` (at port 8080 or any other).
2. Start the Backend (`TicketLinterApplication`) at port 8001.
3. Run `gatsby develop` which by default listens on port 8000.

Use [ngrok](https://ngrok.com/) to forward https://something.ngrok.io to http://localhost:8080 (or the port where `TicketLinterGatewayApplication` is listening).

NOTES
- When starting up the backend set the env variables `APP_KEY` and `APP_BASE_URL`
- When running gatsby develop, set the variable GATSBY_API_BASE_URL e.g. `GATSBY_API_BASE_URL=https://covidio.ngrok.io gatsby develop`